### PR TITLE
Add impl From<(f64, f64)> for Point; re-export OrderedFloat type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,5 @@ pub use voronoi::voronoi;
 pub use point::Point;
 pub use dcel::{DCEL, make_line_segments, make_polygons};
 pub use lloyd::{lloyd_relaxation, polygon_centroid};
+
+pub use ordered_float::OrderedFloat;

--- a/src/point.rs
+++ b/src/point.rs
@@ -95,3 +95,10 @@ impl Ord for Point {
         } else { return Ordering::Less; }
     }
 }
+
+impl<T: Into<f64>, U: Into<f64>> From<(T, U)> for Point {
+    fn from(other: (T, U)) -> Self {
+        let (first, second) = other;
+        Point::new(first.into(), second.into())
+    }
+}


### PR DESCRIPTION
Since a Point is made of OrderedFloat types, and it comes from another
crate, the only way for a user of this library to create a Point is by
adding a dependency on ordered_float in their own project, causing
unnecessary dependency bloat.

This allows users to use the OrderedFloat type used in this crate, or
create a Point using a tuple of floats.

Signed-off-by: Alek Ratzloff <alekratz@gmail.com>