### PR TITLE
Change boxsize into rectangular bounds

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ use voronoi::{voronoi, Point, make_polygons};
 const BOX_SIZE: f64 = 800.;
 // ...
 let vor_pts = vec![Point::new(0.0, 1.0), Point::new(2.0, 3.0), Point::new(10.0, 12.0)];
-let vor_diagram = voronoi(vor_pts, BOX_SIZE);
+let vor_diagram = voronoi(vor_pts, (BOX_SIZE, BOX_SIZE));
 let vor_polys = make_polygons(&vor_diagram);
 ```
 

--- a/benches/genvoronoi.rs
+++ b/benches/genvoronoi.rs
@@ -31,7 +31,7 @@ mod tests {
         let points = vec![Point::new(0.0, 1.0)];
 
         b.iter(|| {
-            voronoi(points.clone(), BOX_SIZE);
+            voronoi(points.clone(), (BOX_SIZE, BOX_SIZE));
         });
     }
 
@@ -40,7 +40,7 @@ mod tests {
         let points = generate_points(100);
 
         b.iter(|| {
-            voronoi(points.clone(), BOX_SIZE);
+            voronoi(points.clone(), (BOX_SIZE, BOX_SIZE));
         });
     }
 
@@ -50,7 +50,7 @@ mod tests {
         let points = generate_points(10000);
 
         b.iter(|| {
-            voronoi(points.clone(), BOX_SIZE);
+            voronoi(points.clone(), (BOX_SIZE, BOX_SIZE));
         });
     }
 }

--- a/src/lloyd.rs
+++ b/src/lloyd.rs
@@ -14,8 +14,8 @@ pub fn polygon_centroid(pts: &Vec<Point>) -> Point {
 /// Produces the Lloyd Relaxation of a set of points.
 ///
 /// Each point is moved to the centroid of its Voronoi cell.
-pub fn lloyd_relaxation(pts: Vec<Point>, box_size: f64) -> Vec<Point> {
-    let voronoi = voronoi(pts, box_size);
+pub fn lloyd_relaxation(pts: Vec<Point>, bounds: (f64, f64)) -> Vec<Point> {
+    let voronoi = voronoi(pts, bounds);
     let faces = make_polygons(&voronoi);
     faces.iter().map(polygon_centroid).collect::<Vec<Point>>()
 }


### PR DESCRIPTION
This PR allow users to specify 2 different sizes for the `bounds` (x and y) instead of a square `boxsize`.

While it is simpler than the proposed implementation in https://github.com/petosegan/rust_voronoi/issues/2, the results are the same as one can simply translate all the output points to rescale the domain.

This also fix the last issue reported here https://github.com/petosegan/rust_voronoi/issues/4#issuecomment-653849135